### PR TITLE
Added EridiumLib and MissionSelector

### DIFF
--- a/scripts/RepoInfo.json
+++ b/scripts/RepoInfo.json
@@ -1,3 +1,5 @@
 [
-  "https://raw.githubusercontent.com/apple1417/bl-sdk-mods/master/modinfo.json"
+  "https://raw.githubusercontent.com/apple1417/bl-sdk-mods/master/modinfo.json",
+  "https://raw.githubusercontent.com/RLNT/bl2_eridium/main/modinfo.json",
+  "https://raw.githubusercontent.com/RLNT/bl2_missionselector/main/modinfo.json"
 ]


### PR DESCRIPTION
I chose to add both at once via one pull request since `EridiumLib` is a dependency for `MissionSelector` but we use different repositories for our mods.

I wasn't really sure what I should take for the license for the `EridiumLib` since we use `LGPL-2.1` and that's not an option in your list but I can correct that later on. :)