### PR TITLE
update rlnt mods location

### DIFF
--- a/scripts/RepoInfo.json
+++ b/scripts/RepoInfo.json
@@ -1,9 +1,9 @@
 [
   "https://raw.githubusercontent.com/apple1417/bl-sdk-mods/master/modinfo.json",
-  "https://raw.githubusercontent.com/RLNT/bl2_deathtrapshield/main/modinfo.json",
-  "https://raw.githubusercontent.com/RLNT/bl2_eridium/main/modinfo.json",
-  "https://raw.githubusercontent.com/RLNT/bl2_missionselector/main/modinfo.json",
-  "https://raw.githubusercontent.com/RLNT/bl2_skilltoggles/main/modinfo.json",
+  "https://raw.githubusercontent.com/DAmNRelentless/bl2-deathtrapshield/main/modinfo.json",
+  "https://raw.githubusercontent.com/DAmNRelentless/bl2-eridiumlib/main/modinfo.json",
+  "https://raw.githubusercontent.com/DAmNRelentless/bl2-missionselector/main/modinfo.json",
+  "https://raw.githubusercontent.com/DAmNRelentless/bl2-skilltoggles/main/modinfo.json",
   "https://raw.githubusercontent.com/juso40/bl2sdk_Mods/master/modinfo.json",
   "https://raw.githubusercontent.com/plu5/p-borderlands/main/modinfo.json",
   "https://raw.githubusercontent.com/FromDarkHell/bl-sdk-mods/main/ModInfo.json",


### PR DESCRIPTION
The organization no longer exists and the repos are now hosted on my personal account. I updated them accordingly.