### PR TITLE
Add Milo's BL2 mods to RepoInfo.json

### DIFF
--- a/scripts/RepoInfo.json
+++ b/scripts/RepoInfo.json
@@ -27,5 +27,6 @@
   "https://raw.githubusercontent.com/slserpent/bl-sdk-mods/main/modinfo.json",
   "https://raw.githubusercontent.com/aa3615058/Lengyu-BL2-sdk-Mods/main/modinfo.json",
   "https://gist.githubusercontent.com/Decept1x/3d134d9b0ce21ec9f1f41a1aaa8736c4/raw/modinfo.json",
-  "https://raw.githubusercontent.com/Sampletext282/bl2-mods/master/modinfo.json"
+  "https://raw.githubusercontent.com/Sampletext282/bl2-mods/master/modinfo.json",
+  "https://raw.githubusercontent.com/ncalvin1/Milo-BL2-SDK-Mods/refs/heads/main/modinfo.json"
 ]


### PR DESCRIPTION
All right... let's try this again.  Added version dicts to modinfo, and fixed the source link while I was there.

Adds a link to six BL2/TPS/AoDK mods:
  - CharacterRandomizer gives a player a random selection of skills, and optionally updates the class mods to match.
  - EffectRandomizer randomly tweaks class mods, shields, relics, and guns to give them different behavior.
  - StorageManager combines several previous bank and backpack resizing mods into a single one that works across all three games.
  - MyFavoriteMod blocks selling or dropping starred items.
  - LilithPatch modifies the action skill of 55tumbl's Lilith mod to behave more like the BL1 version.
  - ChangeUtil is a utility library that makes tracking and reverting changes to BL2 objects simpler.