### PR TITLE
Add Cleaning Up Pandora+

### DIFF
--- a/_willow2_mods/CleaningUpPandoraPlus.md
+++ b/_willow2_mods/CleaningUpPandoraPlus.md
@@ -1,0 +1,19 @@
+---
+author: identity
+coop_support: Unknown
+dependencies: []
+download: https://github.com/infernumx/bl-sdk-mods/releases/download/cleaning-up-pandora-plus/cleaning_up_pandora_plus.sdkmod
+legacy: false
+redirect_from:
+- /mods/CleaningUpPandoraPlus/
+supported_games:
+- BL2
+title: Cleaning Up Pandora+
+urls:
+  Source Code: https://github.com/infernumx/bl-sdk-mods/tree/main/cleaning_up_pandora_plus
+version: '1.0'
+---
+Adds the ability to sell items that are on the floor or in your backpack by pressing a user-set keybind.
+
+NOTE:<ul><li>Items that are favorited or equipped cannot be sold.</li><li>All sold items can be bought back from any vendor.</li></ul>
+Credits to Deceptix_ for the original code


### PR DESCRIPTION
Adds the ability to sell items that are on the floor or in your backpack by pressing a user-set keybind.

NOTE:<ul><li>Items that are favorited or equipped cannot be sold.</li><li>All sold items can be bought back from any vendor.</li></ul>
Credits to Deceptix_ for the original code