### PR TITLE
Add Autordonite to mod DB

### DIFF
--- a/_oak2_mods/Autordonite.md
+++ b/_oak2_mods/Autordonite.md
@@ -1,0 +1,13 @@
+---
+pyproject_url: https://raw.githubusercontent.com/jlangowells/bl4_ordonite_helper/refs/heads/main/pyproject.toml
+---
+# Autordonite
+
+Annoyed at having to grapple and throw ordonite canisters during the ordonite processor events?
+Want to use an action skill or heavy weapon that prevents grappling?
+Autordonite deposits the canisters for you so you can focus on mobbing combat.
+
+## Features
+
+- Automatically deposite ordonite canisters in the ordonite processor.
+- Bind a key to manually deposite ordonite canisters instead if preferred.


### PR DESCRIPTION
Autordonite is a mod for automatically depositing ordonite canisters in the ordonite processor events.