### PR TITLE
Add EnemyBalancer to the willow2 mod DB

### DIFF
--- a/_willow2_mods/EnemyBalancer.md
+++ b/_willow2_mods/EnemyBalancer.md
@@ -1,0 +1,3 @@
+---
+pyproject_url: https://raw.githubusercontent.com/galqawala/EnemyBalancer/refs/heads/main/pyproject.toml
+---


### PR DESCRIPTION
EnemyBalancer is already listed under `_willow1_mods` (it started as a BL1-only mod). It now supports BL2 and TPS as well, from the same codebase and `pyproject.toml`, so it should also appear here.

## Summary
- Adds `_willow2_mods/EnemyBalancer.md`, same minimal `pyproject_url` format already used by the existing `_willow1_mods/EnemyBalancer.md` and `_willow2_mods/AutoLoot.md` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)