### PR TITLE
Add 22 BL1 mods by eeriegoesd

### DIFF
--- a/_willow1_mods/ContinuousFire.md
+++ b/_willow1_mods/ContinuousFire.md
@@ -1,0 +1,5 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/ContinuousFire/pyproject.toml
+---
+
+Guns that fire in bursts keep firing while you hold the trigger.

--- a/_willow1_mods/CrashDebug.md
+++ b/_willow1_mods/CrashDebug.md
@@ -1,0 +1,15 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/CrashDebug/pyproject.toml
+---
+
+Keeps a running note of what every mod is doing, so after a crash you can see which one
+ran last.
+
+## Settings
+
+- **Save the note to**: Desktop, Documents or the mods folder.
+- **File type**: `.log` or `.txt`.
+- **Saved to**: the full path of the note, so you always know where to find it.
+- **Follow Other Mods**: whether the note names which mod is running. Turn it off to only
+  record area changes.
+- **Lines Kept**: how many lines the note holds before it starts over.

--- a/_willow1_mods/GearScore.md
+++ b/_willow1_mods/GearScore.md
@@ -1,0 +1,21 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/GearScore/pyproject.toml
+---
+
+Rates every weapon by DPS and shield by Shield Power according to in-game formula, on item cards wherever you see it (character skills not counted).
+
+The number shows on item cards in your backpack, in vending machines, on mission rewards
+and on loot lying on the ground. Page Up and Page Down in the backpack shows a DPS page,
+listing everything you carry best first.
+
+Weapons: `shots x damage x pellets / (shots x fire interval + reload)`, where shots is
+the magazine divided by the ammo each shot costs. Shields:
+`capacity + recharge rate x (60 - recharge delay)`. Every number comes off the item
+itself, unrounded, so it can differ slightly from the card.
+
+## Settings
+
+- **Disregard Accuracy**: Assumes every bullet hits. Turn it off and the DPS is scaled by the gun's accuracy.
+- **Disregard Critical**: Ignores critical hits. Turn it off and the DPS is multiplied by the gun's own critical bonus, as if every shot were a critical.
+- **Disregard Elements**: Ignores burn, shock and corrosion. Turn it off and the extra damage an elemental gun throws is added, scaled by its x1 to x4 rating.
+- **Score font size**: How big the number is printed on the card.

--- a/_willow1_mods/HideFullPickups.md
+++ b/_willow1_mods/HideFullPickups.md
@@ -1,0 +1,8 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/HideFullPickups/pyproject.toml
+---
+
+Stops ammo you cannot carry from lighting up on the ground.
+
+Anything that would say FULL loses its beam and its icon. Spend some ammo and the beam
+comes back.

--- a/_willow1_mods/InfiniteAmmo.md
+++ b/_willow1_mods/InfiniteAmmo.md
@@ -1,0 +1,9 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/InfiniteAmmo/pyproject.toml
+---
+
+Firing never uses up your ammo.
+
+## Settings
+
+- **No Reload**: your magazine never runs down, so there is nothing to reload.

--- a/_willow1_mods/InfiniteHealth.md
+++ b/_willow1_mods/InfiniteHealth.md
@@ -1,0 +1,5 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/InfiniteHealth/pyproject.toml
+---
+
+Nothing can take your health down.

--- a/_willow1_mods/JumpHigher.md
+++ b/_willow1_mods/JumpHigher.md
@@ -1,0 +1,10 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/JumpHigher/pyproject.toml
+---
+
+Lets you jump higher than the game allows.
+
+## Settings
+
+- **Jump Height**: how hard you push off the ground. The game's own number is 630.
+- **Show jump height [DEBUG]**: prints how high your last jump went.

--- a/_willow1_mods/LootRadar.md
+++ b/_willow1_mods/LootRadar.md
@@ -1,0 +1,31 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/LootRadar/pyproject.toml
+---
+
+Marks loot and unopened chests on your compass, with the distance to each one.
+
+Ammo you have no room for is left out.
+The distance to each mark is written above it.
+
+## Mark colours
+
+- Green: weapons and items
+- Yellow: money
+- Blue: ammo and health
+- Red: an unopened red chest
+- White: an unopened white chest
+
+## Settings
+
+- **Show Weapon Loot**: Weapons and items on the compass.
+- **Show Money Loot**: Money on the compass.
+- **Show Ammo Loot**: Ammo and health on the compass.
+- **Show Red Chests**: Red chests nobody has opened yet.
+- **Show White Chests**: White chests nobody has opened yet.
+- **Display Only Better Weapons**: Hides weapons that are worse than the worst one of that
+  type you already carry, and stops you picking them up. Score is shots x damage x pellets,
+  divided by (shots x fire interval plus reload), where shots is the magazine divided by
+  the ammo each shot costs.
+- **Hide Full Pickups**: Ammo you cannot carry stops lighting up.
+- **Show Distance**: How far away each mark is, written above it.
+- **Units**: Metres or feet.

--- a/_willow1_mods/MissionProgress.md
+++ b/_willow1_mods/MissionProgress.md
@@ -1,0 +1,20 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/MissionProgress/pyproject.toml
+---
+
+Shows your mission progress and total game completion, following the Borderlands
+mission flow.
+
+## What each line means
+
+- Blue: how much of the game you have finished
+- Yellow: the mission you are tracking in the log
+- Red: missions the available before the one you are tracking, still unfinished
+- Grey: what comes next
+
+## Settings
+
+- **Enable DLC Missions**: 216 missions instead of 126.
+- **Flag Skipped Missions**: The red list on or off.
+- **Achievement Warnings**: A red note when a known bug in the current mission can cost you an achievement.
+- **Upcoming missions shown**: How many missions to list ahead.

--- a/_willow1_mods/MovementSpeedChanger.md
+++ b/_willow1_mods/MovementSpeedChanger.md
@@ -1,0 +1,17 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/MovementSpeedChanger/pyproject.toml
+---
+
+Sets how fast you walk, run, aim, crouch and drive.
+
+Each slider shows the game's own number next to its name, so you always know what you
+are changing it from.
+
+## Settings
+
+- **Walking**: your normal speed on foot.
+- **Running**: the speed of a sprint.
+- **Aiming**: the speed while looking down sights.
+- **Crouching**: the speed while crouched.
+- **Driving**: the top speed of any vehicle you are driving.
+- **Show movement speed [DEBUG]**: prints your speed and which of the five is in use.

--- a/_willow1_mods/NoBackpackLimit.md
+++ b/_willow1_mods/NoBackpackLimit.md
@@ -1,0 +1,9 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/NoBackpackLimit/pyproject.toml
+---
+
+Sets the backpack capacity limit.
+
+## Settings
+
+- **Backpack slots**: the backpack capacity limit. The game's own number is 15.

--- a/_willow1_mods/NoRecoil.md
+++ b/_willow1_mods/NoRecoil.md
@@ -1,0 +1,9 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/NoRecoil/pyproject.toml
+---
+
+Removes recoil from all weapons.
+
+## Settings
+
+- **Also Stop Spread**: every shot lands dead centre instead of scattering around the crosshair.

--- a/_willow1_mods/NoReload.md
+++ b/_willow1_mods/NoReload.md
@@ -1,0 +1,5 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/NoReload/pyproject.toml
+---
+
+Your magazine never runs down.

--- a/_willow1_mods/NoSkillCooldown.md
+++ b/_willow1_mods/NoSkillCooldown.md
@@ -1,0 +1,7 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/NoSkillCooldown/pyproject.toml
+---
+
+Your action skill is ready every time you press the key.
+
+Pressing the key while your action skill is active ends it and starts it again.

--- a/_willow1_mods/ObjectiveDistance.md
+++ b/_willow1_mods/ObjectiveDistance.md
@@ -1,0 +1,21 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/ObjectiveDistance/pyproject.toml
+---
+
+Shows how far your objective is, plus a line on the ground showing the way.
+
+## What it draws
+
+- A distance reading, under the compass or at the top of the screen
+- A line on the ground to your objective
+
+The line follows the paths the game's own characters walk, and points where your compass
+waypoint points.
+
+## Settings
+
+- **Show Distance**: The reading on or off.
+- **Show Route Line**: The line on the ground on or off.
+- **Units**: Metres or feet.
+- **Position**: Under the compass or top of screen.
+- **Route Colour**: Green, blue, red, yellow or orange.

--- a/_willow1_mods/RepeatMission.md
+++ b/_willow1_mods/RepeatMission.md
@@ -1,0 +1,13 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/RepeatMission/pyproject.toml
+---
+
+Lets you repeat any mission you have already completed, or set it ready to turn in.
+
+## Settings
+
+- **Mission**: which mission to work on.
+- **Repeat Selected Mission**: puts it back in your log to be done again.
+- **Ready to Turn In**: puts it straight to ready to hand in.
+- **Mark Complete**: marks it finished.
+- **Refresh the List**: looks again at what is in your log.

--- a/_willow1_mods/ResetChests.md
+++ b/_willow1_mods/ResetChests.md
@@ -1,0 +1,11 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/ResetChests/pyproject.toml
+---
+
+Shuts every red and white chest you have opened in this area.
+
+## Settings
+
+- **Reset Chests in This Area**: press it to shut the chests around you.
+- **Reset Red Chests**: whether red chests are included.
+- **Reset White Chests**: whether white chests are included.

--- a/_willow1_mods/RunAndWalk.md
+++ b/_willow1_mods/RunAndWalk.md
@@ -1,0 +1,14 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/RunAndWalk/pyproject.toml
+---
+
+Makes running and walking work off a hold key and a toggle key.
+
+- Shift to hold while running
+- Caps Lock binds a manual running toggle instead
+- You can change these bindings in the mod settings
+
+## Settings
+
+- **Camera Effect**: the view widens while running. Turn it off to leave the camera alone.
+- **Show movement speed [DEBUG]**: prints your speed and whether auto run is on.

--- a/_willow1_mods/SellValue.md
+++ b/_willow1_mods/SellValue.md
@@ -1,0 +1,9 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/SellValue/pyproject.toml
+---
+
+Shows what an item sells for on its card.
+
+## Settings
+
+- **Sell value font size**: how big the line is on the card.

--- a/_willow1_mods/Teleport.md
+++ b/_willow1_mods/Teleport.md
@@ -1,0 +1,11 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/Teleport/pyproject.toml
+---
+
+Takes you to any place you have already been to in this playthrough.
+
+## Settings
+
+- **Place**: where you want to go.
+- **Go There**: press it to travel.
+- **Refresh the List**: looks again at where you have been.

--- a/_willow1_mods/UseNoReload.md
+++ b/_willow1_mods/UseNoReload.md
@@ -1,0 +1,8 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/UseNoReload/pyproject.toml
+---
+
+Stops the "E" (Use) key from reloading your gun.
+
+In the stock game, pressing Use with nothing in front of you reloads. Reloading is left
+to the reload key alone.

--- a/_willow1_mods/VehicleLoot.md
+++ b/_willow1_mods/VehicleLoot.md
@@ -1,0 +1,14 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/VehicleLoot/pyproject.toml
+---
+
+Picks loot up while you are driving.
+
+Anything within reach of the vehicle is collected as you drive past.
+
+## Settings
+
+- **Reach in metres**: How close the loot has to be.
+- **Loot Weapons**: Weapons and items.
+- **Loot Money**: Money.
+- **Loot Ammo**: Ammo and health.


### PR DESCRIPTION
Adds 22 Borderlands 1 mods to the willow1 database. All are GPL3, support both GOTY and GOTY Enhanced, and live in one repo: https://github.com/EerieGoesD/borderlands-1-goty-mods

Continuous Fire, Crash Debug, Gear Score, Hide Full Pickups, Infinite Ammo, Infinite Health, Jump Higher, Loot Radar, Mission Progress, Movement Speed Changer, No Backpack Limit, No Recoil, No Reload, No Skill Cooldown, Objective Distance, Repeat Mission, Reset Chests, Run And Walk, Sell Value, Teleport, Use No Reload, Vehicle Loot.