### PR TITLE
Add support link to eeriegoesd's mod pages

### DIFF
--- a/_willow1_mods/ContinuousFire.md
+++ b/_willow1_mods/ContinuousFire.md
@@ -3,3 +3,6 @@ pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-m
 ---
 
 Guns that fire in bursts keep firing while you hold the trigger.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/CrashDebug.md
+++ b/_willow1_mods/CrashDebug.md
@@ -13,3 +13,6 @@ ran last.
 - **Follow Other Mods**: whether the note names which mod is running. Turn it off to only
   record area changes.
 - **Lines Kept**: how many lines the note holds before it starts over.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/GearScore.md
+++ b/_willow1_mods/GearScore.md
@@ -19,3 +19,6 @@ itself, unrounded, so it can differ slightly from the card.
 - **Disregard Critical**: Ignores critical hits. Turn it off and the DPS is multiplied by the gun's own critical bonus, as if every shot were a critical.
 - **Disregard Elements**: Ignores burn, shock and corrosion. Turn it off and the extra damage an elemental gun throws is added, scaled by its x1 to x4 rating.
 - **Score font size**: How big the number is printed on the card.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/HideFullPickups.md
+++ b/_willow1_mods/HideFullPickups.md
@@ -6,3 +6,6 @@ Stops ammo you cannot carry from lighting up on the ground.
 
 Anything that would say FULL loses its beam and its icon. Spend some ammo and the beam
 comes back.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/InfiniteAmmo.md
+++ b/_willow1_mods/InfiniteAmmo.md
@@ -7,3 +7,6 @@ Firing never uses up your ammo.
 ## Settings
 
 - **No Reload**: your magazine never runs down, so there is nothing to reload.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/InfiniteHealth.md
+++ b/_willow1_mods/InfiniteHealth.md
@@ -3,3 +3,6 @@ pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-m
 ---
 
 Nothing can take your health down.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/JumpHigher.md
+++ b/_willow1_mods/JumpHigher.md
@@ -8,3 +8,6 @@ Lets you jump higher than the game allows.
 
 - **Jump Height**: how hard you push off the ground. The game's own number is 630.
 - **Show jump height [DEBUG]**: prints how high your last jump went.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/LootRadar.md
+++ b/_willow1_mods/LootRadar.md
@@ -29,3 +29,6 @@ The distance to each mark is written above it.
 - **Hide Full Pickups**: Ammo you cannot carry stops lighting up.
 - **Show Distance**: How far away each mark is, written above it.
 - **Units**: Metres or feet.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/MissionProgress.md
+++ b/_willow1_mods/MissionProgress.md
@@ -18,3 +18,6 @@ mission flow.
 - **Flag Skipped Missions**: The red list on or off.
 - **Achievement Warnings**: A red note when a known bug in the current mission can cost you an achievement.
 - **Upcoming missions shown**: How many missions to list ahead.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/MovementSpeedChanger.md
+++ b/_willow1_mods/MovementSpeedChanger.md
@@ -15,3 +15,6 @@ are changing it from.
 - **Crouching**: the speed while crouched.
 - **Driving**: the top speed of any vehicle you are driving.
 - **Show movement speed [DEBUG]**: prints your speed and which of the five is in use.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/NoBackpackLimit.md
+++ b/_willow1_mods/NoBackpackLimit.md
@@ -7,3 +7,6 @@ Sets the backpack capacity limit.
 ## Settings
 
 - **Backpack slots**: the backpack capacity limit. The game's own number is 15.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/NoRecoil.md
+++ b/_willow1_mods/NoRecoil.md
@@ -7,3 +7,6 @@ Removes recoil from all weapons.
 ## Settings
 
 - **Also Stop Spread**: every shot lands dead centre instead of scattering around the crosshair.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/NoReload.md
+++ b/_willow1_mods/NoReload.md
@@ -3,3 +3,6 @@ pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-m
 ---
 
 Your magazine never runs down.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/NoSkillCooldown.md
+++ b/_willow1_mods/NoSkillCooldown.md
@@ -5,3 +5,6 @@ pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-m
 Your action skill is ready every time you press the key.
 
 Pressing the key while your action skill is active ends it and starts it again.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/ObjectiveDistance.md
+++ b/_willow1_mods/ObjectiveDistance.md
@@ -19,3 +19,6 @@ waypoint points.
 - **Units**: Metres or feet.
 - **Position**: Under the compass or top of screen.
 - **Route Colour**: Green, blue, red, yellow or orange.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/RepeatMission.md
+++ b/_willow1_mods/RepeatMission.md
@@ -11,3 +11,6 @@ Lets you repeat any mission you have already completed, or set it ready to turn 
 - **Ready to Turn In**: puts it straight to ready to hand in.
 - **Mark Complete**: marks it finished.
 - **Refresh the List**: looks again at what is in your log.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/ResetChests.md
+++ b/_willow1_mods/ResetChests.md
@@ -9,3 +9,6 @@ Shuts every red and white chest you have opened in this area.
 - **Reset Chests in This Area**: press it to shut the chests around you.
 - **Reset Red Chests**: whether red chests are included.
 - **Reset White Chests**: whether white chests are included.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/RunAndWalk.md
+++ b/_willow1_mods/RunAndWalk.md
@@ -12,3 +12,6 @@ Makes running and walking work off a hold key and a toggle key.
 
 - **Camera Effect**: the view widens while running. Turn it off to leave the camera alone.
 - **Show movement speed [DEBUG]**: prints your speed and whether auto run is on.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/SellValue.md
+++ b/_willow1_mods/SellValue.md
@@ -7,3 +7,6 @@ Shows what an item sells for on its card.
 ## Settings
 
 - **Sell value font size**: how big the line is on the card.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/Teleport.md
+++ b/_willow1_mods/Teleport.md
@@ -9,3 +9,6 @@ Takes you to any place you have already been to in this playthrough.
 - **Place**: where you want to go.
 - **Go There**: press it to travel.
 - **Refresh the List**: looks again at where you have been.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/UseNoReload.md
+++ b/_willow1_mods/UseNoReload.md
@@ -6,3 +6,6 @@ Stops the "E" (Use) key from reloading your gun.
 
 In the stock game, pressing Use with nothing in front of you reloads. Reloading is left
 to the reload key alone.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).

--- a/_willow1_mods/VehicleLoot.md
+++ b/_willow1_mods/VehicleLoot.md
@@ -12,3 +12,6 @@ Anything within reach of the vehicle is collected as you drive past.
 - **Loot Weapons**: Weapons and items.
 - **Loot Money**: Money.
 - **Loot Ammo**: Ammo and health.
+
+For full information about this mod and to report bugs, please visit
+[eeriegoesd.com/gaming/mods](https://eeriegoesd.com/gaming/mods/).


### PR DESCRIPTION
Adds a closing line to my 22 mod pages pointing at https://eeriegoesd.com/gaming/mods/ for full information and bug reports. No other changes.