### PR TITLE
Update No Backpack Limit settings text

### DIFF
--- a/_willow1_mods/NoBackpackLimit.md
+++ b/_willow1_mods/NoBackpackLimit.md
@@ -6,4 +6,7 @@ Sets the backpack capacity limit.
 
 ## Settings
 
-- **Backpack slots**: the backpack capacity limit. The game's own number is 15.
+- **Backpack slots**: the backpack capacity limit, up to 1000.
+
+Turning the mod off puts the backpack back to the size that character had, upgrades
+included.


### PR DESCRIPTION
The slider now goes to 1000 and turning the mod off restores the character's own backpack size instead of 15.