### PR TITLE
Add AutoLootBL1E

### DIFF
--- a/_willow1_mods/AutoLootBL1E.md
+++ b/_willow1_mods/AutoLootBL1E.md
@@ -1,0 +1,3 @@
+---
+pyproject_url: https://raw.githubusercontent.com/galqawala/AutoLootBL1E/refs/heads/master/pyproject.toml
+---


### PR DESCRIPTION
Adds a listing for AutoLootBL1E, a from-scratch BL1E (Willow1) port of AutoLoot's feature set - automatically picks up weapons, shields, grenade mods, class mods, artifacts and SDUs.

Repo: https://github.com/galqawala/AutoLootBL1E