### PR TITLE
Add AutopickupBL1E

### DIFF
--- a/_willow1_mods/AutopickupBL1E.md
+++ b/_willow1_mods/AutopickupBL1E.md
@@ -1,0 +1,3 @@
+---
+pyproject_url: https://raw.githubusercontent.com/galqawala/AutopickupBL1E/refs/heads/master/pyproject.toml
+---


### PR DESCRIPTION
BL1E (GOTY Enhanced) port of [MOW531/RedxYeti's Auto-Pickup SDK](https://github.com/MOW531/MOW531-BL1-SDK-Mods/tree/main/Autopickup%20SDK) (already listed here as `Autopickup.md`, BL1-only). Repo: https://github.com/galqawala/AutopickupBL1E

Rewrites the collection mechanism to hook the game's pickup lifecycle directly rather than patching item flags, since BL1E's native auto-pickup didn't reliably catch items ejected in bursts from containers. GPL-3.0, same as the original, with the original authors credited in `pyproject.toml` and in the repo's README.