### PR TITLE
Add ColorRandomizer

### DIFF
--- a/_willow1_mods/ColorRandomizer.md
+++ b/_willow1_mods/ColorRandomizer.md
@@ -1,0 +1,3 @@
+---
+pyproject_url: https://raw.githubusercontent.com/galqawala/ColorRandomizer/refs/heads/master/pyproject.toml
+---


### PR DESCRIPTION
Randomizes the player's character colors and head accessory on spawn in BL1/BL1E, with a reroll keybind (default Insert). Repo: https://github.com/galqawala/ColorRandomizer

Uses `WillowPlayerController.SetPlayerUIPreferences`, the same function the character-customization screen itself calls. GPL-3.0.