### PR TITLE
Update Jump Higher settings text

### DIFF
--- a/_willow1_mods/JumpHigher.md
+++ b/_willow1_mods/JumpHigher.md
@@ -6,5 +6,5 @@ Lets you jump higher than the game allows.
 
 ## Settings
 
-- **Jump Height**: how far off the ground you go, up to 10000. The game's own jump is about 190.
+- **Jump Height**: how far off the ground you go, from 240 up to 10000. The game's own jump is about 240.
 - **Show jump height [DEBUG]**: prints how high your last jump went.


### PR DESCRIPTION
The Jump Height setting now starts at 240, which is the game's own jump. Updating the description to match.