### PR TITLE
Add No Clip

### DIFF
--- a/_willow1_mods/NoClip.md
+++ b/_willow1_mods/NoClip.md
@@ -1,0 +1,12 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/NoClip/pyproject.toml
+---
+
+Lets you fly through walls.
+
+Press the key to lift off. You fly wherever you are aiming, and nothing stops you.
+Press it again to drop back on your feet.
+
+## Settings
+
+- **Fly Speed**: how fast you move while flying.


### PR DESCRIPTION
Adds No Clip, a BL1 mod that lets you fly through walls.

Repo: https://github.com/EerieGoesD/borderlands-1-goty-mods