### PR TITLE
Add Reset Enemies

### DIFF
--- a/_willow1_mods/ResetEnemies.md
+++ b/_willow1_mods/ResetEnemies.md
@@ -1,0 +1,9 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/ResetEnemies/pyproject.toml
+---
+
+Brings the enemies in the area back without reloading your save.
+
+## Settings
+
+- **Reset Current Area**: press it, close the menu, and the enemies come back at their own spawn points.


### PR DESCRIPTION
Adds Reset Enemies to the BL1 mod database.

Brings the enemies in the area back without reloading your save. Tested on GOTY and GOTY Enhanced.