### PR TITLE
Add Auto Loot

### DIFF
--- a/_willow1_mods/AutoLoot.md
+++ b/_willow1_mods/AutoLoot.md
@@ -1,0 +1,12 @@
+---
+pyproject_url: https://raw.githubusercontent.com/EerieGoesD/borderlands-1-goty-mods/refs/heads/main/AutoLoot/pyproject.toml
+---
+
+Picks loot up as you walk over it, no key press needed.
+
+## Settings
+
+- **Loot Weapons**: whether weapons and items are picked up.
+- **Loot Money**: whether money is picked up.
+- **Loot Ammo**: whether ammo and health are picked up.
+- **Reach in metres**: how close the loot has to be.


### PR DESCRIPTION
Adds Auto Loot to the BL1 mod database.

Picks loot up as you walk over it, no key press needed. Tested on GOTY and GOTY Enhanced.